### PR TITLE
fix: switch default image to Google hosted one

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -26,5 +26,5 @@ variable "name" {
 
 variable "image" {
   description = "container image to deploy"
-  default     = "gcr.io/ahmetb-public/zoneprinter"
+  default     = "gcr.io/google-samples/zone-printer:0.2"
 }


### PR DESCRIPTION
Hello, I tried this terraform setting but it failed since it looks like the previous image is not hosted at [gcr.io/ahmetb-public/zoneprinter](https://gcr.io/ahmetb-public/zoneprinter) anymore.

This PR changes the default image for `zone-printer` to the one hosted by Google here: https://console.cloud.google.com/gcr/images/google-samples/global/zone-printer

**Error I encountered**

```sh
> terraform apply

(...)

module.lb-http.google_compute_global_address.default[0]: Creating...
google_cloud_run_service.default["asia-northeast1"]: Creating...
google_cloud_run_service.default["asia-northeast2"]: Creating...
google_cloud_run_service.default["asia-northeast2"]: Still creating... [10s elapsed]
module.lb-http.google_compute_global_address.default[0]: Still creating... [10s elapsed]
module.lb-http.google_compute_global_address.default[0]: Creation complete after 12s [id=projects/shuuji3/global/addresses/shuuji3-hello-address]
╷
│ Error: Error waiting to create Service: resource is in failed state "Ready:False", message: Image 'gcr.io/ahmetb-public/zoneprinter' not found.
│ 
│   with google_cloud_run_service.default["asia-northeast1"],
│   on main.tf line 5, in resource "google_cloud_run_service" "default":
│    5: resource "google_cloud_run_service" "default" {
│ 
╵
╷
│ Error: Error waiting to create Service: resource is in failed state "Ready:False", message: Image 'gcr.io/ahmetb-public/zoneprinter' not found.
│ 
│   with google_cloud_run_service.default["asia-northeast2"],
│   on main.tf line 5, in resource "google_cloud_run_service" "default":
│    5: resource "google_cloud_run_service" "default" {
│ 
╵
```